### PR TITLE
Fix User Emotion Prefetch Manager

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -1,10 +1,10 @@
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
 
 from base.models import BaseModel
 
 
-class UserEmotionPrefetchManager(models.Manager):
+class UserEmotionPrefetchManager(BaseUserManager):
     """Manager to automatically add `prefetch_related` to the useremotion_set for a given user"""
     def get_queryset(self):
         return super().get_queryset().prefetch_related(


### PR DESCRIPTION
#22 Users Cannot Authenticate

TEST PLAN

1) Run Unit Tests
- ASSERT they pass

2) Attempt to login with a valid user/password combination
- ASSERT login success

3) Regression against the `cached_emotions` manager
- ASSERT it still works as expected