### PR TITLE
Fix Create Playlist On Spotify Task

### DIFF
--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -84,7 +84,10 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
         try:
             logger.info('Creating playlist for user {} with name {}'.format(spotify_user_id, playlist_name))
             playlist_id = spotify.create_playlist(auth_code, spotify_user_id, playlist_name)
-            logger.info('Created playlist for user {} with name {} successfully'.format(spotify_user_id, playlist_name))
+            logger.info(
+                'Created playlist for user {} with name {} successfully'.format(spotify_user_id, playlist_name),
+                extra={'fingerprint': fingerprint_base.format(msg='created_spotify_playlist')}
+            )
         except SpotifyException:
             logger.exception('Error creating playlist for user {}'.format(spotify_user_id), extra={
                 'fingerprint': fingerprint_base.format(msg='failed_creating_playlist'),
@@ -110,7 +113,7 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
 
         logger.info(
             'Added songs to playlist {} successfully'.format(playlist_id),
-            extra={'fingerprint': fingerprint_base.format(msg='created_spotify_playlist')}
+            extra={'fingerprint': fingerprint_base.format(msg='success_adding_songs_to_spotify_playlist')}
         )
     except SpotifyException:
         logger.exception('Error adding songs to playlist {} for user {}'.format(playlist_id, spotify_user_id), extra={

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -92,7 +92,7 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
                 'playlist_name': playlist_name,
                 'songs': songs
             })
-            raise
+            self.retry()
 
     try:
         logger.info('Adding songs to playlist {}'.format(playlist_id))
@@ -108,4 +108,4 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
             'playlist_name': playlist_name,
             'songs': songs
         })
-        raise
+        self.retry()

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -101,6 +101,10 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
         # Break up the total list of songs into batches of 100
         batched_songs = spotify.batch_tracks(songs)
 
+        # First, remove songs from playlist to clear out already existing songs
+        for batch in batched_songs:
+            spotify.delete_songs_from_playlist(auth_code, playlist_id, batch)
+
         for batch in batched_songs:
             spotify.add_songs_to_playlist(auth_code, playlist_id, batch)
 

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -73,7 +73,7 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
                 playlist_id = playlist['id']
                 break
     except SpotifyException:
-        logger.exception('Error getting playlist for user {}'.format(spotify_user_id), extra={
+        logger.warning('Error getting playlists for user {}'.format(spotify_user_id), extra={
             'fingerprint': fingerprint_base.format(msg='failed_getting_user_playlists'),
             'spotify_user_id': spotify_user_id,
             'playlist_name': playlist_name,

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -96,7 +96,14 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
 
     try:
         logger.info('Adding songs to playlist {}'.format(playlist_id))
-        spotify.add_songs_to_playlist(auth_code, playlist_id, songs)
+
+        # Spotify has a limit of 100 songs per request to add songs to a playlist
+        # Break up the total list of songs into batches of 100
+        batched_songs = spotify.batch_tracks(songs)
+
+        for batch in batched_songs:
+            spotify.add_songs_to_playlist(auth_code, playlist_id, batch)
+
         logger.info(
             'Added songs to playlist {} successfully'.format(playlist_id),
             extra={'fingerprint': fingerprint_base.format(msg='created_spotify_playlist')}

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -58,7 +58,8 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
     :param songs: (list) Collection of Spotify track URIs to add to playlist
 
     """
-    spotify = SpotifyClient()
+    spotify = SpotifyClient(identifier='create_spotify_playlist_from_songs_{}'.format(spotify_user_id))
+    fingerprint_base = 'tunes.tasks.create_spotify_playlist_from_songs.{msg}'
     playlist_id = None
 
     try:
@@ -73,6 +74,7 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
                 break
     except SpotifyException:
         logger.exception('Error getting playlist for user {}'.format(spotify_user_id), extra={
+            'fingerprint': fingerprint_base.format(msg='failed_getting_user_playlists'),
             'spotify_user_id': spotify_user_id,
             'playlist_name': playlist_name,
             'songs': songs
@@ -85,6 +87,7 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
             logger.info('Created playlist for user {} with name {} successfully'.format(spotify_user_id, playlist_name))
         except SpotifyException:
             logger.exception('Error creating playlist for user {}'.format(spotify_user_id), extra={
+                'fingerprint': fingerprint_base.format(msg='failed_creating_playlist'),
                 'spotify_user_id': spotify_user_id,
                 'playlist_name': playlist_name,
                 'songs': songs
@@ -96,10 +99,11 @@ def create_spotify_playlist_from_songs(self, auth_code, spotify_user_id, playlis
         spotify.add_songs_to_playlist(auth_code, playlist_id, songs)
         logger.info(
             'Added songs to playlist {} successfully'.format(playlist_id),
-            extra={'fingerprint': 'created_playlist_success'}
+            extra={'fingerprint': fingerprint_base.format(msg='created_spotify_playlist')}
         )
     except SpotifyException:
         logger.exception('Error adding songs to playlist {} for user {}'.format(playlist_id, spotify_user_id), extra={
+            'fingerprint': fingerprint_base.format(msg='failed_adding_songs_to_playlist'),
             'spotify_user_id': spotify_user_id,
             'playlist_name': playlist_name,
             'songs': songs

--- a/apps/moodytunes/tests/test_tasks.py
+++ b/apps/moodytunes/tests/test_tasks.py
@@ -61,10 +61,17 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
         cls.playlist_name = 'new_playlist'
         cls.songs = ['spotify:track:1']
 
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
-    def test_happy_path(self, mock_get_user_playlists, mock_create_playlist, mock_add_songs_to_playlist):
+    def test_happy_path(
+            self,
+            mock_get_user_playlists,
+            mock_create_playlist,
+            mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
+    ):
         mock_get_user_playlists.return_value = {'items': []}
 
         playlist_id = 'spotify:playlist:id'
@@ -76,6 +83,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
         mock_add_songs_to_playlist.assert_called_once_with(self.auth_code, playlist_id, self.songs)
 
     @mock.patch('moodytunes.tasks.create_spotify_playlist_from_songs.retry')
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
@@ -84,6 +92,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
             mock_get_user_playlists,
             mock_create_playlist,
             mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
             mock_retry
     ):
         mock_get_user_playlists.return_value = {'items': []}
@@ -95,6 +104,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
         mock_retry.assert_called_once()
 
     @mock.patch('moodytunes.tasks.create_spotify_playlist_from_songs.retry')
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
@@ -103,6 +113,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
             mock_get_user_playlists,
             mock_create_playlist,
             mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
             mock_retry
     ):
         mock_get_user_playlists.return_value = {'items': []}
@@ -116,6 +127,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
 
         mock_retry.assert_called_once()
 
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
@@ -123,7 +135,8 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
             self,
             mock_get_user_playlists,
             mock_create_playlist,
-            mock_add_songs_to_playlist
+            mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
     ):
         playlist_id = 'spotify:playlist:id'
         mock_get_user_playlists.return_value = {'items': [{'name': self.playlist_name, 'id': playlist_id}]}
@@ -134,6 +147,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
         mock_create_playlist.assert_not_called()
         mock_add_songs_to_playlist.assert_called_once_with(self.auth_code, playlist_id, self.songs)
 
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
@@ -141,7 +155,8 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
             self,
             mock_get_user_playlists,
             mock_create_playlist,
-            mock_add_songs_to_playlist
+            mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
     ):
         playlist_id = 'spotify:playlist:id'
         mock_get_user_playlists.return_value = {'items': [{'name': 'some_other_playlist', 'id': '12345'}]}
@@ -154,6 +169,7 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
         mock_create_playlist.assert_called_once_with(self.auth_code, self.spotify_user_id, self.playlist_name)
         mock_add_songs_to_playlist.assert_called_once_with(self.auth_code, playlist_id, self.songs)
 
+    @mock.patch('libs.spotify.SpotifyClient.delete_songs_from_playlist')
     @mock.patch('libs.spotify.SpotifyClient.add_songs_to_playlist')
     @mock.patch('libs.spotify.SpotifyClient.create_playlist')
     @mock.patch('libs.spotify.SpotifyClient.get_user_playlists')
@@ -161,7 +177,8 @@ class TestCreateSpotifyPlaylistFromSongs(TestCase):
             self,
             mock_get_user_playlists,
             mock_create_playlist,
-            mock_add_songs_to_playlist
+            mock_add_songs_to_playlist,
+            mock_delete_songs_from_playlist,
     ):
         mock_get_user_playlists.side_effect = SpotifyException
 

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -281,11 +281,8 @@ class SpotifyClient(object):
 
         :return: (list[dict]) Song mappings + (energy, valence)
         """
-        batch_size = 100
-
-        # Create a list of lists of tracks, each one being at most batch_size length
-        # Spotify allows up to 100 songs to be processed at once
-        batched_tracks = [tracks[idx:idx + batch_size] for idx in range(0, len(tracks), batch_size)]
+        # Need to batch tracks as Spotify limits the number of tracks sent in one request
+        batched_tracks = self.batch_tracks(tracks)
 
         for batch in batched_tracks:
             url = '{api_url}/audio-features'.format(

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -499,3 +499,27 @@ class SpotifyClient(object):
         resp = self._make_spotify_request('POST', url, headers=headers, data=json.dumps(data))
 
         return resp
+
+    def delete_songs_from_playlist(self, auth_code, playlist_id, songs):
+        """
+        Remove songs from a specified playlist
+
+        :param auth_code: (str) SpotifyUserAuth access_token for the given user
+        :param playlist_id: (str) Spotify playlist ID to remove songs from
+        :param songs: (list) Collection of Spotify track URIs to remove from playlist
+        """
+        url = '{api_url}/playlists/{playlist_id}/tracks'.format(
+            api_url=settings.SPOTIFY['api_url'],
+            playlist_id=playlist_id
+        )
+
+        headers = {
+            'Authorization': 'Bearer {}'.format(auth_code),
+            'Content-Type': 'application/json'
+        }
+
+        data = {'uris': songs}
+
+        resp = self._make_spotify_request('DELETE', url, headers=headers, data=json.dumps(data))
+
+        return resp

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -159,6 +159,18 @@ class SpotifyClient(object):
 
         return resp.get('access_token')
 
+    def batch_tracks(self, tracks):
+        """
+        Some Spotify endpoints have a limit of 100 tracks for one request. This method will
+        take a list of tracks and create a list of batches for including in Spotify requests
+
+        :param tracks: (list) List of tracks
+
+        :return: (list[list])
+        """
+        batch_size = 100
+        return [tracks[idx:idx + batch_size] for idx in range(0, len(tracks), batch_size)]
+
     def get_playlists_for_category(self, category, num_playlists):
         """
         Get a number of playlists from Spotify for a given category
@@ -484,6 +496,6 @@ class SpotifyClient(object):
 
         data = {'uris': songs}
 
-        resp = self._make_spotify_request('PUT', url, headers=headers, data=json.dumps(data))
+        resp = self._make_spotify_request('POST', url, headers=headers, data=json.dumps(data))
 
         return resp

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -542,8 +542,20 @@ class TestSpotifyClient(TestCase):
 
         self.assertEqual(retrieved_response, mock_response)
         mock_request.assert_called_once_with(
-            'PUT',
+            'POST',
             'https://api.spotify.com/v1/playlists/{}/tracks'.format(playlist_id),
             headers=expected_headers,
             data=json.dumps(expected_data)
         )
+
+    def test_batch_tracks_batches_list(self):
+        items = [i for i in range(200)]
+        batched_items = self.spotify_client.batch_tracks(items)
+
+        self.assertEqual(len(batched_items), 2)
+
+    def test_batch_tracks_works_on_lists_with_less_than_batch_size(self):
+        items = [i for i in range(20)]
+        batched_items = self.spotify_client.batch_tracks(items)
+
+        self.assertEqual(len(batched_items), 1)

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -548,6 +548,32 @@ class TestSpotifyClient(TestCase):
             data=json.dumps(expected_data)
         )
 
+    @mock.patch('libs.spotify.SpotifyClient._make_spotify_request')
+    def test_delete_songs_from_playlist(self, mock_request):
+        auth_code = 'spotify-auth-id'
+        playlist_id = 'spotify:playlist:id'
+        songs = ['spotify:track:1', 'spotify:track:2']
+        mock_response = {'resp': 'OK'}
+
+        mock_request.return_value = mock_response
+
+        expected_headers = {
+            'Authorization': 'Bearer {}'.format(auth_code),
+            'Content-Type': 'application/json'
+        }
+
+        expected_data = {'uris': songs}
+
+        retrieved_response = self.spotify_client.delete_songs_from_playlist(auth_code, playlist_id, songs)
+
+        self.assertEqual(retrieved_response, mock_response)
+        mock_request.assert_called_once_with(
+            'DELETE',
+            'https://api.spotify.com/v1/playlists/{}/tracks'.format(playlist_id),
+            headers=expected_headers,
+            data=json.dumps(expected_data)
+        )
+
     def test_batch_tracks_batches_list(self):
         items = [i for i in range(200)]
         batched_items = self.spotify_client.batch_tracks(items)


### PR DESCRIPTION
When refactoring some logging messages, it was discovered that the task as written would fail on playlists that had more than 100 songs in them. This is due to a limitation on Spotify's API that limits the number of tracks to be added to a playlist in one request. We batch the tracks to be added into bundles of 100 and send them in multiple requests.

As a result, we also needed to change the method we use to add songs to the playlist. We need to use the POST method to add songs to a playlist instead of a PUT request, as the PUT replaces all tracks in the playlist. This means that in the case of a playlist larger than 100 tracks, only the last batch would appear in the playlist. We switched over to using a delete and replace pattern for the playlist.