### PR TITLE
Configure periodic tasks to store result state

### DIFF
--- a/apps/accounts/tasks.py
+++ b/apps/accounts/tasks.py
@@ -8,7 +8,6 @@ logger = getLogger(__name__)
 
 
 class CreateUserEmotionRecordsForUserTask(MoodyBaseTask):
-    name = 'accounts.tasks.CreateUserEmotionRecordsForUser'
 
     def run(self, user_id, *args, **kwargs):
         """
@@ -34,7 +33,6 @@ class CreateUserEmotionRecordsForUserTask(MoodyBaseTask):
 
 
 class UpdateUserEmotionRecordAttributeTask(MoodyBaseTask):
-    name = 'accounts.tasks.UpdateUserEmotionRecordAttributeTask'
 
     def run(self, vote_id, *args, **kwargs):
         """

--- a/apps/base/tasks.py
+++ b/apps/base/tasks.py
@@ -14,6 +14,7 @@ class MoodyBaseTask(Task):
 class MoodyPeriodicTask(MoodyBaseTask, PeriodicTask):
     abstract = True
     run_every = None
+    ignore_result = None
 
 
 class ClearExpiredSessionsTask(MoodyPeriodicTask):

--- a/apps/base/tasks.py
+++ b/apps/base/tasks.py
@@ -18,7 +18,6 @@ class MoodyPeriodicTask(MoodyBaseTask, PeriodicTask):
 
 
 class ClearExpiredSessionsTask(MoodyPeriodicTask):
-    name = 'base.tasks.ClearExpiredSessionsTask'
     run_every = crontab(minute=0, hour=2, day_of_week=0)
 
     """Task to clean expired sessions from session storage"""

--- a/apps/moodytunes/tasks.py
+++ b/apps/moodytunes/tasks.py
@@ -9,8 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 class FetchSongFromSpotifyTask(MoodyBaseTask):
-    name = 'moodytunes.tasks.FetchSongFromSpotifyTask'
-
     max_retries = 3
     default_retry_delay = 60 * 15
 
@@ -68,8 +66,6 @@ class FetchSongFromSpotifyTask(MoodyBaseTask):
 
 
 class CreateSpotifyPlaylistFromSongsTask(MoodyBaseTask):
-    name = 'moodytunes.tasks.CreateSpotifyPlaylistFromSongsTask'
-
     max_retries = 3
     default_retry_delay = 60 * 15
 

--- a/apps/tunes/tasks.py
+++ b/apps/tunes/tasks.py
@@ -11,7 +11,6 @@ logger = getLogger(__name__)
 
 
 class CreateSongsFromSpotifyTask(MoodyPeriodicTask):
-    name = 'tunes.tasks.CreateSongsFromSpotifyTask'
     run_every = crontab(minute=0, hour=1, day_of_week=0)
 
     max_retries = 3


### PR DESCRIPTION
By default, the `PeriodicTask` class does not store TaskResults. We should enable this to store results of our periodic tasks