### PR TITLE
Refactor update of UserEmotion attributes on delete vote to task

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -183,7 +183,3 @@ class UserSongVote(BaseModel):
         # We don't actually want to delete these records, so just set the vote value to false
         self.vote = False
         self.save()
-
-        # Update attributes for the emotion for user after deleting vote
-        user_emot = self.user.get_user_emotion_record(self.emotion.name)
-        user_emot.update_attributes()

--- a/apps/accounts/signals.py
+++ b/apps/accounts/signals.py
@@ -19,7 +19,9 @@ post_save.connect(
 
 
 def update_user_emotion_attributes(sender, instance, created, *args, **kwargs):
-    if instance.vote and created:
+    if created and instance.vote:
+        UpdateUserEmotionRecordAttributeTask().delay(instance.pk)
+    elif not created:
         UpdateUserEmotionRecordAttributeTask().delay(instance.pk)
 
 

--- a/apps/accounts/tests/test_signals.py
+++ b/apps/accounts/tests/test_signals.py
@@ -27,8 +27,8 @@ class TestUpdateUserAttributesSignal(TestCase):
         cls.emotion = Emotion.objects.get(name=Emotion.HAPPY)
 
     @mock.patch('accounts.models.UserEmotion.update_attributes')
-    def test_upvoting_song_updates_attributes(self, mock_update):
-        vote = UserSongVote.objects.create(
+    def test_upvoting_song_calls_updates_attributes(self, mock_update):
+        UserSongVote.objects.create(
             user=self.user,
             emotion=self.emotion,
             song=self.song,
@@ -37,12 +37,8 @@ class TestUpdateUserAttributesSignal(TestCase):
 
         mock_update.assert_called_once()
 
-        # If we save the vote again, we shouldn't trigger another update
-        vote.save()
-        self.assertEqual(mock_update.call_count, 1)
-
     @mock.patch('accounts.models.UserEmotion.update_attributes')
-    def test_downvoting_song_does_not_update_attributes(self, mock_update):
+    def test_downvoting_song_does_not_call_update_attributes(self, mock_update):
         UserSongVote.objects.create(
             user=self.user,
             emotion=self.emotion,
@@ -51,3 +47,18 @@ class TestUpdateUserAttributesSignal(TestCase):
         )
 
         mock_update.assert_not_called()
+
+    @mock.patch('accounts.models.UserEmotion.update_attributes')
+    def test_deleting_vote_calls_update_attributes(self, mock_update):
+        vote = UserSongVote.objects.create(
+            user=self.user,
+            emotion=self.emotion,
+            song=self.song,
+            vote=True
+        )
+
+        mock_update.reset_mock()
+
+        vote.delete()
+
+        mock_update.assert_called_once()


### PR DESCRIPTION
Used to be in the UserSongVote delete method, which was in the request/response cycle. Refactoring the save signal moves all of the update work to the update task, which should be more performant.