### PR TITLE
Refactor average function to use fewer queries

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -11,7 +11,7 @@ from encrypted_model_fields.fields import EncryptedCharField
 from base.models import BaseModel
 from base.validators import validate_decimal_value
 from libs.spotify import SpotifyClient, SpotifyException
-
+from libs.utils import average
 
 logger = getLogger(__name__)
 
@@ -142,19 +142,11 @@ class UserEmotion(BaseModel):
         """
         votes = self.user.usersongvote_set.filter(emotion=self.emotion, vote=True)
 
-        vote_data = votes.aggregate(
-            Avg('song__energy'),
-            Avg('song__valence'),
-            Avg('song__danceability'),
-        )
+        vote_data = average(votes, 'song__valence', 'song__energy', 'song__danceability')
+        self.valence = vote_data['song__valence__avg']
+        self.energy = vote_data['song__energy__avg']
+        self.danceability = vote_data['song__danceability__avg']
 
-        valence = vote_data['song__valence__avg']
-        energy = vote_data['song__energy__avg']
-        danceability = vote_data['song__danceability__avg']
-
-        self.valence = valence and round(valence, 2)
-        self.energy = energy and round(energy, 2)
-        self.danceability = danceability and round(danceability, 2)
         self.save()
 
 

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.db.models import Avg, Count
 from django.utils import timezone
 from encrypted_model_fields.fields import EncryptedCharField
 
@@ -178,6 +179,33 @@ class UserSongVote(BaseModel):
 
     def __str__(self):
         return '{} - {} - {}'.format(self.user, self.song, self.emotion)
+
+    @classmethod
+    def get_attributes_for_emotion_and_context(cls, user_id, emotion_name, context):
+        """
+        Return the average of  upvoted Song attributes for a given User, Emotion, and Context values.
+        This is needed because of the way we cross the attribute values for a user and emotion with the
+        attribute values for a user, emotion, and context.
+
+        TODO: Maybe move this to the UserEmotion model?
+
+        :param user_id: (int) Primary key for the MoodyUser
+        :param emotion_name: (str) Code for Emotion record to fetch
+        :param context: (str) Choice for context field for a UserSongVote
+
+        :return: (dict) Payload of upvoted song attributes for the given user, emotion, and context
+        """
+        return cls.objects.filter(
+            user__id=user_id,
+            emotion__name=emotion_name,
+            context=context,
+            vote=True
+        ).aggregate(
+            avg_energy=Avg('song__energy'),
+            avg_valence=Avg('song__valence'),
+            avg_danceability=Avg('song__danceability'),
+            count=Count('vote')
+        )
 
     def delete(self, *args, **kwargs):
         # We don't actually want to delete these records, so just set the vote value to false

--- a/apps/accounts/tests/test_models.py
+++ b/apps/accounts/tests/test_models.py
@@ -65,14 +65,15 @@ class TestUserEmotion(TestCase):
 
         votes = UserSongVote.objects.filter(user=self.user)
 
-        expected_new_energy = average(votes, 'song__energy')
-        expected_new_valence = average(votes, 'song__valence')
-        expected_new_danceability = average(votes, 'song__danceability')
+        expected_attributes = average(votes, 'song__valence', 'song__energy', 'song__danceability')
+        expected_valence = expected_attributes['song__valence__avg']
+        expected_energy = expected_attributes['song__energy__avg']
+        expected_danceability = expected_attributes['song__danceability__avg']
 
         user_emot.update_attributes()
-        self.assertEqual(user_emot.energy, expected_new_energy)
-        self.assertEqual(user_emot.valence, expected_new_valence)
-        self.assertEqual(user_emot.danceability, expected_new_danceability)
+        self.assertEqual(user_emot.energy, expected_energy)
+        self.assertEqual(user_emot.valence, expected_valence)
+        self.assertEqual(user_emot.danceability, expected_danceability)
 
     def test_update_attributes_sets_values_to_default_if_no_songs_upvoted(self):
         emotion = Emotion.objects.get(name=Emotion.HAPPY)
@@ -229,14 +230,17 @@ class TestUserSongVote(TestCase):
 
         vote_to_delete.delete()
 
-        upvoted_votes = UserSongVote.objects.filter(user=self.user, vote=True)
-        expected_new_energy = average(upvoted_votes, 'song__energy')
-        expected_new_valence = average(upvoted_votes, 'song__valence')
+        upvotes = UserSongVote.objects.filter(user=self.user, vote=True)
+        expected_attributes = average(upvotes, 'song__valence', 'song__energy', 'song__danceability')
+        expected_valence = expected_attributes['song__valence__avg']
+        expected_energy = expected_attributes['song__energy__avg']
+        expected_danceability = expected_attributes['song__danceability__avg']
 
         user_emot.refresh_from_db()
 
-        self.assertEqual(user_emot.energy, expected_new_energy)
-        self.assertEqual(user_emot.valence, expected_new_valence)
+        self.assertEqual(user_emot.energy, expected_energy)
+        self.assertEqual(user_emot.valence, expected_valence)
+        self.assertEqual(user_emot.danceability, expected_danceability)
 
     def test_deleting_all_votes_updates_attributes_to_defaults(self):
         user_emot = self.user.useremotion_set.get(emotion__name=Emotion.HAPPY)

--- a/apps/accounts/tests/test_models.py
+++ b/apps/accounts/tests/test_models.py
@@ -42,8 +42,8 @@ class TestUserEmotion(TestCase):
 
     def test_update_attributes_sets_values_to_average_of_upvoted_songs(self):
         emotion = Emotion.objects.get(name=Emotion.HAPPY)
-        song = MoodyUtil.create_song(energy=.50, valence=.75)
-        song2 = MoodyUtil.create_song(energy=.60, valence=.85)
+        song = MoodyUtil.create_song(energy=.50, valence=.75, danceability=.45)
+        song2 = MoodyUtil.create_song(energy=.60, valence=.85, danceability=.85)
         user_emot = UserEmotion.objects.create(user=self.user, emotion=emotion)
 
         # Skip the post_save signal on UserSongVote to delay updating the attributes
@@ -67,15 +67,17 @@ class TestUserEmotion(TestCase):
 
         expected_new_energy = average(votes, 'song__energy')
         expected_new_valence = average(votes, 'song__valence')
+        expected_new_danceability = average(votes, 'song__danceability')
 
         user_emot.update_attributes()
         self.assertEqual(user_emot.energy, expected_new_energy)
         self.assertEqual(user_emot.valence, expected_new_valence)
+        self.assertEqual(user_emot.danceability, expected_new_danceability)
 
     def test_update_attributes_sets_values_to_default_if_no_songs_upvoted(self):
         emotion = Emotion.objects.get(name=Emotion.HAPPY)
-        song = MoodyUtil.create_song(energy=.50, valence=.75)
-        song2 = MoodyUtil.create_song(energy=.60, valence=.85)
+        song = MoodyUtil.create_song(energy=.50, valence=.75, danceability=.45)
+        song2 = MoodyUtil.create_song(energy=.60, valence=.85, danceability=.85)
         user_emot = UserEmotion.objects.create(user=self.user, emotion=emotion)
 
         UserSongVote.objects.create(
@@ -93,12 +95,14 @@ class TestUserEmotion(TestCase):
         )
 
         self.user.usersongvote_set.filter(emotion=emotion).update(vote=False)
-        expected_new_energy = emotion.energy
-        expected_new_valence = emotion.valence
+        default_emotion_energy = emotion.energy
+        default_emotion_valence = emotion.valence
+        default_emotion_danceability = emotion.danceability
 
         user_emot.update_attributes()
-        self.assertEqual(user_emot.energy, expected_new_energy)
-        self.assertEqual(user_emot.valence, expected_new_valence)
+        self.assertEqual(user_emot.energy, default_emotion_energy)
+        self.assertEqual(user_emot.valence, default_emotion_valence)
+        self.assertEqual(user_emot.danceability, default_emotion_danceability)
 
 
 class TestMoodyUser(TestCase):

--- a/apps/accounts/tests/test_tasks.py
+++ b/apps/accounts/tests/test_tasks.py
@@ -58,11 +58,14 @@ class TestUpdateUserEmotionTask(TestCase):
         user_emotion = self.user.get_user_emotion_record(self.emotion.name)
         user_votes = self.user.usersongvote_set.all()
 
-        expected_valence = average(user_votes, 'song__valence')
-        expected_energy = average(user_votes, 'song__energy')
+        expected_attributes = average(user_votes, 'song__valence', 'song__energy', 'song__danceability')
+        expected_valence = expected_attributes['song__valence__avg']
+        expected_energy = expected_attributes['song__energy__avg']
+        expected_danceability = expected_attributes['song__danceability__avg']
 
         self.assertEqual(user_emotion.valence, expected_valence)
         self.assertEqual(user_emotion.energy, expected_energy)
+        self.assertEqual(user_emotion.danceability, expected_danceability)
 
     def test_raises_exception_if_user_not_found(self):
         invalid_vote_pk = 10000

--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -211,14 +211,18 @@ class TestAnalyticsView(TestCase):
 
         working_songs = [upvoted_song_1, upvoted_song_2]
         votes = UserSongVote.objects.filter(user=self.user, vote=True)
+        expected_attributes = average(votes, 'song__valence', 'song__energy', 'song__danceability')
+        expected_valence = expected_attributes['song__valence__avg']
+        expected_energy = expected_attributes['song__energy__avg']
+        expected_danceability = expected_attributes['song__danceability__avg']
 
         expected_response = {
             'emotion': emotion.name,
             'emotion_name': emotion.full_name,
             'genre': None,
-            'energy': average(votes, 'song__energy'),
-            'valence': average(votes, 'song__valence'),
-            'danceability': average(votes, 'song__danceability'),
+            'energy': expected_energy,
+            'valence': expected_valence,
+            'danceability': expected_danceability,
             'total_songs': len(working_songs)
         }
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView, PasswordResetView, PasswordResetConfirmView, PasswordChangeView, \
     LogoutView
 from django.core.exceptions import SuspiciousOperation
-from django.db.models import Avg
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse, resolve, Resolver404, reverse_lazy
@@ -21,7 +20,7 @@ from accounts.serializers import AnalyticsSerializer, AnalyticsRequestSerializer
 from accounts.utils import filter_duplicate_votes_on_song_from_playlist
 from base.mixins import GetRequestValidatorMixin
 from tunes.models import Emotion
-
+from libs.utils import average
 
 logger = logging.getLogger(__name__)
 
@@ -172,12 +171,7 @@ class AnalyticsView(GetRequestValidatorMixin, generics.RetrieveAPIView):
 
             votes_for_emotion = filter_duplicate_votes_on_song_from_playlist(votes_for_emotion)
 
-            votes_for_emotion_data = votes_for_emotion.aggregate(
-                Avg('song__energy'),
-                Avg('song__valence'),
-                Avg('song__danceability'),
-            )
-
+            votes_for_emotion_data = average(votes_for_emotion, 'song__valence', 'song__energy', 'song__danceability')
             valence = votes_for_emotion_data['song__valence__avg']
             energy = votes_for_emotion_data['song__energy__avg']
             danceability = votes_for_emotion_data['song__danceability__avg']

--- a/apps/tunes/tests/test_views.py
+++ b/apps/tunes/tests/test_views.py
@@ -361,12 +361,15 @@ class TestVoteView(TestCase):
         self.api_client.post(self.url, data=data, format='json')
 
         votes = UserSongVote.objects.filter(user=self.user, vote=True)
-        expected_energy = average(votes, 'song__energy')
-        expected_valence = average(votes, 'song__valence')
+        expected_attributes = average(votes, 'song__valence', 'song__energy', 'song__danceability')
+        expected_valence = expected_attributes['song__valence__avg']
+        expected_energy = expected_attributes['song__energy__avg']
+        expected_danceability = expected_attributes['song__danceability__avg']
 
         user_emotion.refresh_from_db()
         self.assertEqual(user_emotion.energy, expected_energy)
         self.assertEqual(user_emotion.valence, expected_valence)
+        self.assertEqual(user_emotion.danceability, expected_danceability)
 
     def test_submitting_duplicate_vote_not_allowed(self):
         data = {

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -28,7 +28,7 @@ from tunes.serializers import (
     LastPlaylistSerializer
 )
 from tunes.utils import CachedPlaylistManager, generate_browse_playlist
-from libs.utils import average
+
 
 logger = logging.getLogger(__name__)
 

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -63,16 +63,16 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
 
         # Try to use upvotes for this emotion and context to generate attributes for songs to return
         if self.cleaned_data.get('context'):
-            votes = self.request.user.usersongvote_set.filter(
-                emotion__name=self.cleaned_data['emotion'],
-                context=self.cleaned_data['context'],
-                vote=True
+            context_vote_data = UserSongVote.get_attributes_for_emotion_and_context(
+                self.request.user.id,
+                self.cleaned_data['emotion'],
+                self.cleaned_data['context']
             )
 
-            if votes.exists():
-                energy = average(votes, 'song__energy')
-                valence = average(votes, 'song__valence')
-                danceability = average(votes, 'song__danceability')
+            if context_vote_data['count']:
+                energy = round(context_vote_data['avg_energy'], 2)
+                valence = round(context_vote_data['avg_valence'], 2)
+                danceability = round(context_vote_data['avg_danceability'], 2)
 
         # If context not provided or the previous query on upvotes for context did return any votes,
         # determine attributes from the attributes for the user and emotion

--- a/libs/tests/test_utils.py
+++ b/libs/tests/test_utils.py
@@ -23,11 +23,14 @@ class TestAverage(TestCase):
         self.assertEqual(calculated_attrs['energy__avg'], expected_energy)
         self.assertEqual(calculated_attrs['danceability__avg'], expected_danceability)
 
-    def test_empty_queryset_returns_null(self):
+    def test_empty_queryset_returns_null_values(self):
         collection = Song.objects.none()
 
         calculated_attrs = average(collection, 'valence', 'energy', 'danceability')
-        self.assertIsNone(calculated_attrs)
+
+        self.assertIsNone(calculated_attrs['valence__avg'])
+        self.assertIsNone(calculated_attrs['energy__avg'])
+        self.assertIsNone(calculated_attrs['danceability__avg'])
 
     def test_invalid_attribute_raises_exception(self):
         collection = Song.objects.all()

--- a/libs/tests/test_utils.py
+++ b/libs/tests/test_utils.py
@@ -8,28 +8,41 @@ from libs.tests.helpers import MoodyUtil
 class TestAverage(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.song_1 = MoodyUtil.create_song(energy=.5, valence=.75)
-        cls.song_2 = MoodyUtil.create_song(energy=.65, valence=.45)
+        cls.song_1 = MoodyUtil.create_song(energy=.5, valence=.75, danceability=.5)
+        cls.song_2 = MoodyUtil.create_song(energy=.65, valence=.45, danceability=.75)
 
-    def test_average_computes_proper_average_for_attribute(self):
+    def test_average_computes_proper_average_for_citeria(self):
         collection = Song.objects.all()
         expected_valence = .6
         expected_energy = .57
+        expected_danceability = .62
 
-        calculated_valence = average(collection, 'valence')
-        self.assertEqual(calculated_valence, expected_valence)
+        calculated_attrs = average(collection, 'valence', 'energy', 'danceability')
 
-        calculated_energy = average(collection, 'energy')
-        self.assertEqual(calculated_energy, expected_energy)
+        self.assertEqual(calculated_attrs['valence__avg'], expected_valence)
+        self.assertEqual(calculated_attrs['energy__avg'], expected_energy)
+        self.assertEqual(calculated_attrs['danceability__avg'], expected_danceability)
 
     def test_empty_queryset_returns_null(self):
         collection = Song.objects.none()
 
-        calculated_average = average(collection, 'valence')
-        self.assertIsNone(calculated_average)
+        calculated_attrs = average(collection, 'valence', 'energy', 'danceability')
+        self.assertIsNone(calculated_attrs)
 
-    def test_invalid_attribute_rasies_exception(self):
+    def test_invalid_attribute_raises_exception(self):
         collection = Song.objects.all()
 
         with self.assertRaises(ValueError):
             average(collection, 'foo')
+
+    def test_set_precision_returns_average_to_desired_precision(self):
+        collection = Song.objects.all()
+        expected_valence = .6
+        expected_energy = .575
+        expected_danceability = .625
+
+        calculated_attrs = average(collection, 'valence', 'energy', 'danceability', precision=3)
+
+        self.assertEqual(calculated_attrs['valence__avg'], expected_valence)
+        self.assertEqual(calculated_attrs['energy__avg'], expected_energy)
+        self.assertEqual(calculated_attrs['danceability__avg'], expected_danceability)

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -17,7 +17,7 @@ def average(collection, *criteria, precision=2):
         ret = collection.aggregate(*fields)
 
         if not all(ret.values()):
-            return None
+            return dict([(key, None) for key in ret.keys()])
 
         for key, value in ret.items():
             ret[key] = round(value, precision)

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -2,21 +2,27 @@ from django.core.exceptions import FieldError
 from django.db.models import Avg
 
 
-def average(collection, criteria):
+def average(collection, *criteria, precision=2):
     """
-    Given a QuerySey of records, calculate the average for a given attribute of the set
-    :param collection: (QuerySet) Queryset of records
-    :param criteria: (str) Desired field for calculated average
+    Given a QuerySey of records, calculate the average for given attributes of the set to `precision` decimal places
 
-    :return: (float)
+    :param collection: (QuerySet) Queryset of records
+    :param criteria: (*args[str]) Desired fields for calculated average
+    :param precision: (int) Precision to round values to. Default is 2
+
+    :return: (dict)
     """
     try:
-        val = collection.aggregate(Avg(criteria))['{}__avg'.format(criteria)]
+        fields = [Avg(field) for field in criteria]
+        ret = collection.aggregate(*fields)
 
-        if val is None:
+        if not all(ret.values()):
             return None
 
-        return round(val, 2)
+        for key, value in ret.items():
+            ret[key] = round(value, precision)
+
+        return ret
 
     except FieldError:
         raise ValueError('{} does not have an attribute {}'.format(collection.model, criteria))


### PR DESCRIPTION
Refactor average function to calculate average for list of attributes instead of one attribute at a time. This reduces the amount of queries from n (where n=amount of attributes) to 1