### PR TITLE
Sanitize SpotifyClient Logs

### DIFF
--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -76,7 +76,7 @@ class SpotifyClient(object):
         """
         response = None
 
-        if not headers:  # pragma: no cover
+        if not headers:
             # Retrieve the header we need to make an auth request
             auth_token = self._get_auth_access_token()
             headers = {'Authorization': 'Bearer {}'.format(auth_token)}

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -29,9 +29,10 @@ class SpotifyClient(object):
 
     def _sanitize_log_data(self, data):
         """
-        Redact sensitive data (auth headers, access token, etc.) from logging data
+        Redact sensitive data (auth headers, access tokens, etc.) from logging data and
+        replace with a sanitized value.
 
-        :param data: (dict) Request data to log
+        :param data: (dict) Request data to log that may contain sensitive information
 
         :return: (dict)
         """
@@ -43,7 +44,12 @@ class SpotifyClient(object):
 
     def _log(self, level, msg, extra=None, exc_info=False):
         """
-        Log a message to the logger
+        Log a message to the logger at a given level with optional extra info or traceback info.
+
+        NOTE: Any data passed as `extra` should be a copy of the real data used in the code. This
+        is because we do transformations on the data passed to sanitize sensitive values, so if we
+        operate on the "real data" we could inadvertently update the actual data being used in the
+        code.
 
         :param level: (int) Logging level to log at. Should be a constant from the `logging` library
         :param msg: (str) Log message to write to write
@@ -55,7 +61,7 @@ class SpotifyClient(object):
 
         extra.update({'fingerprint': self.fingerprint})
 
-        # Redact sensitive data from logging data
+        # Redact sensitive information from logging data extra
         for key, data in extra.items():
             if isinstance(data, dict):
                 extra[key] = self._sanitize_log_data(data)

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -80,7 +80,6 @@ class SpotifyClient(object):
 
         :return (dict) Response content
         """
-        response = None
 
         if not headers:
             # Retrieve the header we need to make an auth request
@@ -118,14 +117,10 @@ class SpotifyClient(object):
             self._log(logging.INFO, 'Successful request made to {}.'.format(url))
             self._log(logging.DEBUG, 'Successful request made to {}.'.format(url), extra={'response_data': response})
 
-        except requests.exceptions.HTTPError:
-            response_data = None
+            return response
 
-            # Try to parse error message from response
-            try:
-                response_data = response.json()
-            except Exception:
-                pass
+        except requests.exceptions.HTTPError:
+            response_data = response.json()
 
             self._log(
                 logging.ERROR,
@@ -148,8 +143,6 @@ class SpotifyClient(object):
             self._log(logging.ERROR, 'Received unhandled exception requesting {}'.format(url), exc_info=True)
 
             raise SpotifyException('Received unhandled exception requesting {}'.format(url))
-
-        return response
 
     def _get_auth_access_token(self):
         """

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -21,7 +21,7 @@ class SpotifyException(Exception):
 class SpotifyClient(object):
     """Wrapper around the Spotify API"""
     REDACT_VALUE = '**********'
-    REDACT_DATA_KEYS = ['Authorization', ]
+    REDACT_DATA_KEYS = ['Authorization', 'code']
 
     def __init__(self, identifier='SpotifyClient'):
         self.fingerprint = identifier

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -21,7 +21,7 @@ class SpotifyException(Exception):
 class SpotifyClient(object):
     """Wrapper around the Spotify API"""
     REDACT_VALUE = '**********'
-    REDACT_DATA_KEYS = ['Authorization', 'code']
+    REDACT_DATA_KEYS = ['Authorization', 'code', 'refresh_token']
 
     def __init__(self, identifier='SpotifyClient'):
         self.fingerprint = identifier

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -599,3 +599,18 @@ class TestSpotifyClient(TestCase):
         batched_items = self.spotify_client.batch_tracks(items)
 
         self.assertEqual(len(batched_items), 1)
+
+    def test_sanitize_log_data(self):
+        data = {
+            'code': 'super-secret-code',
+            'foo': 'bar'
+        }
+
+        expected_sanitized_data = {
+            'code': self.spotify_client.REDACT_VALUE,
+            'foo': 'bar'
+        }
+
+        sanitized_data = self.spotify_client._sanitize_log_data(data)
+
+        self.assertDictEqual(sanitized_data, expected_sanitized_data)

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -116,6 +116,35 @@ class TestSpotifyClient(TestCase):
         self.assertDictEqual(resp, dummy_response)
 
     @mock.patch('requests.request')
+    def test_make_spotify_request_uses_headers_if_passed(self, mock_request):
+        dummy_response = {'status': 200, 'content': 'OK'}
+        dummy_headers = {'Foo': 'bar'}
+        dummy_params = {'query': 'param'}
+        dummy_data = {'key': 'value'}
+
+        mock_response = mock.Mock()
+        mock_response.raise_for_status.side_effect = None
+        mock_response.json.return_value = dummy_response
+        mock_request.return_value = mock_response
+
+        resp = self.spotify_client._make_spotify_request(
+            'GET',
+            '/dummy_endpoint',
+            data=dummy_data,
+            params=dummy_params,
+            headers=dummy_headers
+        )
+
+        mock_request.assert_called_with(
+            'GET',
+            '/dummy_endpoint',
+            params=dummy_params,
+            data=dummy_data,
+            headers=dummy_headers
+        )
+        self.assertDictEqual(resp, dummy_response)
+
+    @mock.patch('requests.request')
     @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')
     def test_make_spotify_request_raises_spotify_exception_on_http_error(self, mock_auth, mock_request):
         mock_response = mock.Mock()


### PR DESCRIPTION
Noticed we were logging Authorization headers, access tokens, and other sensitive information. This will scrub the raw values from the data we log so they cannot be read from log files.