### PR TITLE
Fix browse missing user emotion record

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -23,7 +23,8 @@ class MoodyUser(BaseModel, AbstractUser):
     logic needed in course of site flow.
     """
 
-    def get_user_emotion_record(self, emotion_name):
+    @update_logging_data
+    def get_user_emotion_record(self, emotion_name, **kwargs):
         """
         Return the UserEmotion record for a given Emotion name.
 
@@ -34,7 +35,10 @@ class MoodyUser(BaseModel, AbstractUser):
         try:
             return self.useremotion_set.get(emotion__name=emotion_name)
         except UserEmotion.DoesNotExist:
-            logger.error('User {} has no UserEmotion record for {}'.format(self.username, emotion_name))
+            logger.warning(
+                'User {} has no UserEmotion record for {}'.format(self.username, emotion_name),
+                extra={'fingerprint': auto_fingerprint('user_emotion_not_found', **kwargs)}
+            )
             return None
 
     def update_information(self, data):

--- a/apps/tunes/tests/test_views.py
+++ b/apps/tunes/tests/test_views.py
@@ -98,6 +98,27 @@ class TestBrowseView(TestCase):
 
         self.assertEqual(called_jitter, BrowseView.default_jitter)
 
+    @mock.patch('tunes.views.generate_browse_playlist')
+    def test_browse_for_missing_user_emotion_uses_emotion_attributes(self, mock_generate_playlist):
+        user_emotion = self.user.get_user_emotion_record(Emotion.HAPPY)
+        emotion = user_emotion.emotion
+        emotion_energy = emotion.energy
+        emotion_valence = emotion.valence
+        emotion_danceability = emotion.danceability
+        user_emotion.delete()
+
+        params = {'emotion': Emotion.HAPPY}
+        self.api_client.get(self.url, data=params)
+
+        call_args = mock_generate_playlist.mock_calls[0][1]
+        called_energy = call_args[0]
+        called_valence = call_args[1]
+        called_danceability = call_args[2]
+
+        self.assertEqual(called_energy, emotion_energy)
+        self.assertEqual(called_valence, emotion_valence)
+        self.assertEqual(called_danceability, emotion_danceability)
+
     def test_playlist_excludes_previously_voted_songs(self):
         voted_song = MoodyUtil.create_song()
         not_voted_song = MoodyUtil.create_song()

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -79,9 +79,18 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
         # determine attributes from the attributes for the user and emotion
         if energy is None or valence is None or valence is None:
             user_emotion = self.request.user.get_user_emotion_record(self.cleaned_data['emotion'])
-            energy = user_emotion.energy
-            valence = user_emotion.valence
-            danceability = user_emotion.danceability
+
+            # If the user doesn't have a UserEmotion record for the user, fall back to the
+            # attributes for the emotion
+            if not user_emotion:
+                emotion = Emotion.objects.get(name=self.cleaned_data['emotion'])
+                energy = emotion.energy
+                valence = emotion.valence
+                danceability = emotion.danceability
+            else:
+                energy = user_emotion.energy
+                valence = user_emotion.valence
+                danceability = user_emotion.danceability
 
         logger.info(
             'Generating browse playlist for user {}'.format(self.request.user.username),

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -80,8 +80,8 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
         if energy is None or valence is None or valence is None:
             user_emotion = self.request.user.get_user_emotion_record(self.cleaned_data['emotion'])
 
-            # If the user doesn't have a UserEmotion record for the user, fall back to the
-            # attributes for the emotion
+            # If the user doesn't have a UserEmotion record for the emotion, fall back to the
+            # default attributes for the emotion
             if not user_emotion:
                 emotion = Emotion.objects.get(name=self.cleaned_data['emotion'])
                 energy = emotion.energy


### PR DESCRIPTION
If a user browses for an emotion that they don't have a UserEmotion record for, use the emotion attributes for generating the playlist.

Once a user votes on a song, the UserEmotion record will be created via the `UpdateUserEmotionRecordAttributeTask` fired when a UserSongVote is created