### PR TITLE
Refactor SpotifyClient Tests To Mock Request Library

### DIFF
--- a/apps/moodytunes/views.py
+++ b/apps/moodytunes/views.py
@@ -111,7 +111,6 @@ class SpotifyAuthenticationView(TemplateView):
 
         context['spotify_auth_url'] = SpotifyClient.build_spotify_oauth_confirm_link(
             state='user:{}'.format(self.request.user.id),
-            scopes=['playlist-modify-public']
         )
 
         return context

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -364,21 +364,20 @@ class SpotifyClient(object):
         return tracks
 
     @staticmethod
-    def build_spotify_oauth_confirm_link(state, scopes):
+    def build_spotify_oauth_confirm_link(state):
         """
         First step in the Spotify user authorization flow. This builds the request to authorize the application with
         Spotify. Note that this function simply builds the URL for the user to visit, the actual behavior for the
         authorization need to be made client-side.
 
         :param state: (str) State to pass in request. Used for validating redirect URI against request
-        :param scopes: (list) List of scopes to specify when authorizing the application
 
         :return: (str) URL for Spotify OAuth confirmation
         """
         params = {
             'client_id': settings.SPOTIFY['client_id'],
             'response_type': 'code',
-            'scope': ' '.join(scopes),
+            'scope': ' '.join(settings.SPOTIFY['auth_user_scopes']),
             'redirect_uri': settings.SPOTIFY['auth_redirect_uri'],
             'state': state
         }

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -400,24 +400,6 @@ class TestSpotifyClient(TestCase):
 
     @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')
     @mock.patch('requests.request')
-    def test_get_audio_features_handles_missing_track_data(self, mock_request, mock_get_auth_token):
-        mock_get_auth_token.return_value = self.auth_code
-        track = {'code': 'spotify:song:code'}
-        tracks = [track]
-
-        mock_response = mock.Mock()
-        mock_response.json.return_value = {'audio_features': [{}]}
-        mock_request.return_value = mock_response
-
-        resp = self.spotify_client.get_audio_features_for_tracks(tracks)
-        new_track = resp[0]
-
-        self.assertIsNone(new_track.get('energy'))
-        self.assertIsNone(new_track.get('valence'))
-        self.assertIsNone(new_track.get('danceability'))
-
-    @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')
-    @mock.patch('requests.request')
     def test_get_audio_features_for_tracks_skips_tracks_missing_features(self, mock_request, mock_get_auth_token):
         mock_get_auth_token.return_value = self.auth_code
         track = {'code': 'spotify:song:code'}

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -421,10 +421,7 @@ class TestSpotifyClient(TestCase):
         self.assertIsNone(new_track.get('danceability'))
 
     def test_build_spotify_oauth_confirm_link(self):
-        params = {
-            'state': 'user_id=1',
-            'scopes': ['view-playlist', 'edit-playlist']
-        }
+        params = {'state': 'user_id=1'}
 
         url = self.spotify_client.build_spotify_oauth_confirm_link(**params)
 
@@ -434,7 +431,7 @@ class TestSpotifyClient(TestCase):
             'response_type': ['code'],
             'redirect_uri': ['https://moodytunes.vm/moodytunes/spotify/callback/'],
             'state': ['user_id=1'],
-            'scope': ['view-playlist edit-playlist']
+            'scope': ['playlist-modify-public']
         }
         request = parse.urlparse(url)
         request_url = '{}://{}{}'.format(request.scheme, request.netloc, request.path)

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -476,6 +476,7 @@ class TestSpotifyClient(TestCase):
             data=expected_request_data,
             headers=expected_headers
         )
+
         self.assertDictEqual(user_tokens, expected_response_data)
 
     @mock.patch('requests.request')
@@ -571,7 +572,6 @@ class TestSpotifyClient(TestCase):
 
         resp = self.spotify_client.get_user_playlists(auth_code, spotify_user_id)
 
-        self.assertEqual(resp, response_data)
         mock_request.assert_called_once_with(
             'GET',
             'https://api.spotify.com/v1/users/{}/playlists'.format(spotify_user_id),
@@ -579,6 +579,8 @@ class TestSpotifyClient(TestCase):
             headers=expected_headers,
             data=None
         )
+
+        self.assertDictEqual(resp, response_data)
 
     @mock.patch('requests.request')
     def test_create_playlist(self, mock_request):

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -200,19 +200,6 @@ class TestSpotifyClient(TestCase):
 
         resp = self.spotify_client.get_playlists_for_category('category', 1)
 
-        mock_request.assert_called_with(
-            'GET',
-            '{api_url}/browse/categories/{category_id}/playlists'.format(
-                api_url='https://api.spotify.com/v1',
-                category_id='category'
-            ),
-            params={
-                'country': 'US',
-                'limit': 1
-            },
-            data=None,
-            headers={'Authorization': 'Bearer {}'.format(self.auth_code)}
-        )
         self.assertEqual(resp, expected_resp)
 
     @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -432,10 +432,9 @@ class TestSpotifyClient(TestCase):
             'refresh_token': 'some:refresh:token'
         }
 
-        response = mock.Mock()
-        response.json.return_value = resp_data
-
-        mock_request.return_value = response
+        mock_response = mock.Mock()
+        mock_response.json.return_value = resp_data
+        mock_request.return_value = mock_response
 
         user_tokens = self.spotify_client.get_access_and_refresh_tokens(**request_data)
 

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -460,13 +460,16 @@ class TestSpotifyClient(TestCase):
         )
         self.assertDictEqual(user_tokens, expected_response_data)
 
-    @mock.patch('libs.spotify.SpotifyClient._make_spotify_request')
+    @mock.patch('requests.request')
     def test_refresh_access_token(self, mock_request):
         request_data = {'refresh_token': 'some:refresh:token'}
-        resp_data = {'access_token': 'some:access:token'}
-        mock_request.return_value = resp_data
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {'access_token': 'some:access:token'}
+        mock_request.return_value = mock_response
 
         expected_headers = self.spotify_client._make_authorization_header()
+        expected_response_data = {'access_token': 'some:access:token'}
 
         access_token = self.spotify_client.refresh_access_token(**request_data)
 
@@ -475,11 +478,12 @@ class TestSpotifyClient(TestCase):
         mock_request.assert_called_once_with(
             'POST',
             'https://accounts.spotify.com/api/token',
+            params=None,
             headers=expected_headers,
             data=request_data
         )
 
-        self.assertEqual(access_token, resp_data['access_token'])
+        self.assertEqual(access_token, expected_response_data['access_token'])
 
     @mock.patch('libs.spotify.SpotifyClient._make_spotify_request')
     def test_get_user_profile(self, mock_request):

--- a/mtdj/settings/common_api.py
+++ b/mtdj/settings/common_api.py
@@ -17,4 +17,5 @@ SPOTIFY = {
     'auth_redirect_uri': env.str('MTDJ_SPOTIFY_REDIRECT_URI', default='https://moodytunes.vm/moodytunes/spotify/callback/'),
     'auth_cache_key_timeout': 60 * 60,  # Authorization token is good for one hour
     'auth_user_token_timeout': 60 * 60,  # User auth token is good for one hour
+    'auth_user_scopes': ['playlist-modify-public'],
 }


### PR DESCRIPTION
Change the way we mock requests in SpotifyClient tests to actually call the _make_spotify_request method. This would have caught the issue fixed in #381 