### PR TITLE
Refactor get_audio_features to handle zero value attributes

### DIFF
--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -351,7 +351,7 @@ class SpotifyClient(object):
                     energy = track_data.get('energy')
                     danceability = track_data.get('danceability')
 
-                    # Skip tracks that don't have both attributes we're looking for
+                    # Skip tracks that are missing any of the attributes we're looking for
                     if not any([valence, energy, danceability]):
                         continue
 

--- a/libs/spotify.py
+++ b/libs/spotify.py
@@ -352,7 +352,7 @@ class SpotifyClient(object):
                     danceability = track_data.get('danceability')
 
                     # Skip tracks that don't have both attributes we're looking for
-                    if not all([valence, energy, danceability]):
+                    if not any([valence, energy, danceability]):
                         continue
 
                     track.update({

--- a/libs/tests/test_spotify.py
+++ b/libs/tests/test_spotify.py
@@ -400,7 +400,7 @@ class TestSpotifyClient(TestCase):
 
     @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')
     @mock.patch('requests.request')
-    def test_get_audio_features_for_tracks_skips_tracks_missing_features(self, mock_request, mock_get_auth_token):
+    def test_get_audio_features_for_tracks_handles_tracks_missing_features(self, mock_request, mock_get_auth_token):
         mock_get_auth_token.return_value = self.auth_code
         track = {'code': 'spotify:song:code'}
         tracks = [track]
@@ -409,7 +409,29 @@ class TestSpotifyClient(TestCase):
         mock_response.json.return_value = {
             'audio_features': [{
                 'valence': .5,
+                'energy': 0,
+                'danceability': 0
             }]
+        }
+        mock_request.return_value = mock_response
+
+        resp = self.spotify_client.get_audio_features_for_tracks(tracks)
+        new_track = resp[0]
+
+        self.assertEqual(new_track['valence'], .5)
+        self.assertEqual(new_track['energy'], 0)
+        self.assertEqual(new_track['danceability'], 0)
+
+    @mock.patch('libs.spotify.SpotifyClient._get_auth_access_token')
+    @mock.patch('requests.request')
+    def test_get_audio_features_for_tracks_skips_tracks_missing_all_features(self, mock_request, mock_get_auth_token):
+        mock_get_auth_token.return_value = self.auth_code
+        track = {'code': 'spotify:song:code'}
+        tracks = [track]
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            'audio_features': [{}]
         }
         mock_request.return_value = mock_response
 


### PR DESCRIPTION
Some tracks will have an attribute with a value of 0

These tracks should not be skipped if we have other attributes for the track available. We should still skip tracks that are missing all their attributes