### PR TITLE
Remove SpotifyUserAuth from backup targets

### DIFF
--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -133,7 +133,6 @@ DATABASE_BACKUP_TARGETS = [
     'accounts.MoodyUser',
     'accounts.UserEmotion',
     'accounts.UserSongVote',
-    'accounts.SpotifyUserAuth',
     'tunes.Emotion',
     'tunes.Song',
 ]


### PR DESCRIPTION
Output file has plaintext auth tokens, which is a security liability