### PR TITLE
Persist genre param in requests to refresh browse playlist

### DIFF
--- a/static/moodytunes/js/browse.js
+++ b/static/moodytunes/js/browse.js
@@ -4,7 +4,8 @@
     // used in requests for voting on songs
     let emotion,
         jitter,
-        genre;
+        genre,
+        artist;
 
     function init() {
         setUpContextModal();
@@ -178,7 +179,6 @@
 
         let context = sessionStorage.context;
         let description = sessionStorage.description;
-        let artist = artistInput && artistInput.value || undefined;
 
         // Only gather values from input on button press for generating browse playlist
         // This will ensure we persist values across refresh requests when the
@@ -187,6 +187,7 @@
             emotion = document.getElementById('id_emotion').value;
             jitter = document.getElementById('id_jitter').value;
             genre = document.getElementById('id_genre').value || undefined;
+            artist = artistInput && artistInput.value || undefined;
         }
 
         document.MoodyTunesClient.getBrowsePlaylist(

--- a/static/moodytunes/js/browse.js
+++ b/static/moodytunes/js/browse.js
@@ -2,8 +2,9 @@
     // Global variables for API requests to backend
     // Made global to ensure that the same options used in the request are
     // used in requests for voting on songs
-    let emotion;
-    let jitter;
+    let emotion,
+        jitter,
+        genre;
 
     function init() {
         setUpContextModal();
@@ -178,14 +179,14 @@
         let context = sessionStorage.context;
         let description = sessionStorage.description;
         let artist = artistInput && artistInput.value || undefined;
-        let genre = document.getElementById('id_genre').value || undefined;
 
-        // Only gather values from input if request for browse playlist is made
+        // Only gather values from input on button press for generating browse playlist
         // This will ensure we persist values across refresh requests when the
         // user votes on all the songs for their browse playlist
         if (evt && evt.target === generatePlaylistButton) {
             emotion = document.getElementById('id_emotion').value;
             jitter = document.getElementById('id_jitter').value;
+            genre = document.getElementById('id_genre').value || undefined;
         }
 
         document.MoodyTunesClient.getBrowsePlaylist(


### PR DESCRIPTION
Add artist and genre to params persisted in requests for browse playlist after all songs in a playlist have been voted on