### PR TITLE
Lower default browse jitter

### DIFF
--- a/apps/moodytunes/forms.py
+++ b/apps/moodytunes/forms.py
@@ -47,7 +47,7 @@ class BrowseForm(forms.Form):
         required=False,
         min_value=0,
         max_value=0.5,
-        widget=RangeInput(attrs={'step': .05, 'class': 'slider', 'value': .15})
+        widget=RangeInput(attrs={'step': .05, 'class': 'slider', 'value': settings.BROWSE_DEFAULT_JITTER})
     )
 
     def __init__(self, *args, **kwargs):

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -44,8 +44,8 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
     serializer_class = SongSerializer
     queryset = Song.objects.all()
 
-    default_jitter = settings.BROWSE_JITTER
-    default_limit = settings.BROWSE_LIMIT
+    default_jitter = settings.BROWSE_DEFAULT_JITTER
+    default_limit = settings.BROWSE_DEFAULT_LIMIT
 
     get_request_serializer = BrowseSongsRequestSerializer
 

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -45,7 +45,7 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
     queryset = Song.objects.all()
 
     default_jitter = settings.BROWSE_JITTER
-    default_limit = 9
+    default_limit = settings.BROWSE_LIMIT
 
     get_request_serializer = BrowseSongsRequestSerializer
 

--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -44,7 +44,7 @@ class BrowseView(GetRequestValidatorMixin, generics.ListAPIView):
     serializer_class = SongSerializer
     queryset = Song.objects.all()
 
-    default_jitter = .15
+    default_jitter = settings.BROWSE_JITTER
     default_limit = 9
 
     get_request_serializer = BrowseSongsRequestSerializer

--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -353,6 +353,6 @@ LOGGING = {
 }
 
 # BrowseView settings
-BROWSE_DEFAULT_JITTER = .05
-BROWSE_DEFAULT_LIMIT = 9
+BROWSE_DEFAULT_JITTER = env.float('MTDJ_BROWSE_DEFAULT_JITTER', default=0.05)
+BROWSE_DEFAULT_LIMIT = env.int('MTDJ_BROWSE_DEFAULT_LIMIT', default=9)
 BROWSE_PLAYLIST_STRATEGIES = ['energy', 'valence', 'danceability']

--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -355,7 +355,7 @@ LOGGING = {
 # GeoIP Database files
 GEOIP2_DATABASE = os.path.join(BASE_DIR, 'GeoLiteCity.mmdb')
 
-# Strategies for generating browse playlist
+# BrowseView settings
+BROWSE_DEFAULT_JITTER = .05
+BROWSE_DEFAULT_LIMIT = 9
 BROWSE_PLAYLIST_STRATEGIES = ['energy', 'valence', 'danceability']
-BROWSE_JITTER = .05
-BROWSE_LIMIT = 9

--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -358,3 +358,4 @@ GEOIP2_DATABASE = os.path.join(BASE_DIR, 'GeoLiteCity.mmdb')
 # Strategies for generating browse playlist
 BROWSE_PLAYLIST_STRATEGIES = ['energy', 'valence', 'danceability']
 BROWSE_JITTER = .05
+BROWSE_LIMIT = 9

--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -352,9 +352,6 @@ LOGGING = {
     },
 }
 
-# GeoIP Database files
-GEOIP2_DATABASE = os.path.join(BASE_DIR, 'GeoLiteCity.mmdb')
-
 # BrowseView settings
 BROWSE_DEFAULT_JITTER = .05
 BROWSE_DEFAULT_LIMIT = 9

--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -357,3 +357,4 @@ GEOIP2_DATABASE = os.path.join(BASE_DIR, 'GeoLiteCity.mmdb')
 
 # Strategies for generating browse playlist
 BROWSE_PLAYLIST_STRATEGIES = ['energy', 'valence', 'danceability']
+BROWSE_JITTER = .05


### PR DESCRIPTION
Lower the default jitter used for generating browse playlists to .05. This should result in browse playlists more closely aligned with user's attributes for the emotion