### PR TITLE
Fix regex for building first and last mood playlist page links

### DIFF
--- a/apps/tunes/views.py
+++ b/apps/tunes/views.py
@@ -363,10 +363,10 @@ class PlaylistView(GetRequestValidatorMixin, generics.ListAPIView):
         first_page = last_page = None
 
         if resp.data['previous']:
-            first_page = re.sub(r'&page=[1-9]*', '', resp.data['previous'])
+            first_page = re.sub(r'&page=[0-9]*', '', resp.data['previous'])
 
         if resp.data['next']:
-            last_page = re.sub(r'page=[1-9]*', 'page=last', resp.data['next'])
+            last_page = re.sub(r'page=[0-9]*', 'page=last', resp.data['next'])
 
         queryset = self.filter_queryset(self.get_queryset())
 


### PR DESCRIPTION
Originally the regex was missing the 0 character, which caused the links to erroneously include the 0 char in the query string. This updates the regex to also strip the 0 char from the params to ensure that the anchor links are built properly.

Also add more tests around the params for the anchor links.