### PR TITLE
Set logging config to only log gunicorn access logs

### DIFF
--- a/mtdj/settings/common.py
+++ b/mtdj/settings/common.py
@@ -331,7 +331,7 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': False,
         },
-        'gunicorn': {
+        'gunicorn.access': {
             'handlers': ['gunicorn'],
             'level': 'INFO',
             'propagate': False,


### PR DESCRIPTION
Avoid logging traceback on request errors