### PR TITLE
Use on commit function for spotify top artist update signal

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -132,14 +132,7 @@ class SpotifyUserAuth(BaseModel):
             raise
 
         if auth.should_refresh_access_token:
-            try:
-                auth.refresh_access_token()
-            except SpotifyException:
-                logger.warning(
-                    'Failed to update access token for SpotifyUserAuth with pk={}'.format(auth_id),
-                    extra={'fingerprint': auto_fingerprint('failed_to_update_access_token', **kwargs)},
-                )
-                raise
+            auth.refresh_access_token()
 
         return auth
 
@@ -177,15 +170,14 @@ class SpotifyUserAuth(BaseModel):
             )
 
         except SpotifyException:
-            logger.warning(
+            logger.exception(
                 'Unable to refresh access token for {}'.format(self.spotify_user_id),
                 extra={
                     'fingerprint': auto_fingerprint('failed_refresh_access_token', **kwargs),
                     'spotify_username': self.spotify_user_id,
                     'auth_id': self.pk,
                     'user_id': self.user_id
-                },
-                exc_info=True
+                }
             )
 
             raise

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -157,7 +157,7 @@ class SpotifyUserAuth(BaseModel):
     @update_logging_data
     def refresh_access_token(self, **kwargs):
         """Make a call to the Spotify API to refresh the access token for the SpotifyUserAuth record"""
-        spotify_client = SpotifyClient(identifier='refresh-access-token:{}'.format(self.user.username))
+        spotify_client = SpotifyClient(identifier='refresh-access-token:{}'.format(self.spotify_user_id))
 
         try:
             access_token = spotify_client.refresh_access_token(self.refresh_token)
@@ -168,18 +168,23 @@ class SpotifyUserAuth(BaseModel):
             self.save()
 
             logger.info(
-                'Refreshed access token for {}'.format(self.user.username),
+                'Refreshed access token for {}'.format(self.spotify_user_id),
                 extra={
                     'fingerprint': auto_fingerprint('success_refresh_access_token', **kwargs),
-                    'moodytunes_username': self.user.username,
-                    'spotify_username': self.spotify_user_id
+                    'spotify_username': self.spotify_user_id,
+                    'auth_id': self.pk
                 }
             )
 
         except SpotifyException:
             logger.warning(
-                'Unable to refresh access token for {}'.format(self.user.username),
-                extra={'fingerprint': auto_fingerprint('failed_refresh_access_token', **kwargs)},
+                'Unable to refresh access token for {}'.format(self.spotify_user_id),
+                extra={
+                    'fingerprint': auto_fingerprint('failed_refresh_access_token', **kwargs),
+                    'spotify_username': self.spotify_user_id,
+                    'auth_id': self.pk,
+                    'user_id': self.user_id
+                },
                 exc_info=True
             )
 

--- a/apps/accounts/signals.py
+++ b/apps/accounts/signals.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.signals import user_login_failed
 from django.db.models.signals import post_save
+from django.db.transaction import on_commit
 
 from accounts.models import SpotifyUserAuth, UserSongVote
 from accounts.tasks import (
@@ -40,7 +41,7 @@ post_save.connect(
 
 def update_spotify_top_artists(sender, instance, created, *args, **kwargs):
     if created:
-        UpdateTopArtistsFromSpotifyTask().apply_async((instance.pk,), countdown=30)
+        on_commit(lambda: UpdateTopArtistsFromSpotifyTask().delay(instance.pk))
 
 
 post_save.connect(

--- a/apps/accounts/tests/test_signals.py
+++ b/apps/accounts/tests/test_signals.py
@@ -69,7 +69,7 @@ class TestUpdateUserAttributesSignal(TestCase):
 
 
 class TestUpdateSpotifyTopArtistsSignal(TestCase):
-    @mock.patch('accounts.tasks.UpdateTopArtistsFromSpotifyTask.apply_async')
+    @mock.patch('accounts.tasks.UpdateTopArtistsFromSpotifyTask.delay')
     def test_task_is_only_called_on_create(self, mock_task):
         user = MoodyUtil.create_user()
         data = {
@@ -81,7 +81,7 @@ class TestUpdateSpotifyTopArtistsSignal(TestCase):
 
         auth = SpotifyUserAuth.objects.create(**data)
 
-        mock_task.assert_called_once_with((auth.pk,), countdown=30)
+        mock_task.assert_called_once_with(auth.pk)
 
         auth.save()
         self.assertEqual(mock_task.call_count, 1)


### PR DESCRIPTION
Call task once the transaction for creating the `SpotifyUserAuth` record has finished
Avoid having to use the `countdown` param for calling task to update top artists