### PR TITLE
fix: set rev for importanize to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: check-json
 
   - repo: https://github.com/miki725/importanize/
-    rev: '0.7'
+    rev: 'master'
     hooks:
     - id: importanize
       args: [--verbose, --config=.importanize.json]


### PR DESCRIPTION
It seems that 0.7 had a dependency on python3.6 which breaks in
environments that don't have a python3.6 binary. This updates the
rev used in our pre-commit config to `master` which appears to use
whatever python3 binary is available.

See https://github.com/miki725/importanize/issues/64