### PR TITLE
feat: hide Spotify play button border

### DIFF
--- a/static/moodytunes/less/playlist.less
+++ b/static/moodytunes/less/playlist.less
@@ -37,6 +37,7 @@
 
 .play-button {
     height: 90px;
+    border: none;
 }
 
 .song-container {


### PR DESCRIPTION
It looks like Spotify updated the styling of their play buttons
to be more rounded, which results in a weird empty border for our
iframes when we load a play button. This change hides the border
for these iframes so there isn't a weird box looking outline around
the otherwise rounded play buttons.